### PR TITLE
Init/binary build

### DIFF
--- a/main/BUILD
+++ b/main/BUILD
@@ -1,14 +1,14 @@
 cc_library(
-    name = "main_lib",
-    srcs = ["main.cpp", "hello_world.cpp"],
+    name = "hello_world_lib",
+    srcs = ["hello_world.cpp"],
     hdrs = ["hello_world.h"],
     visibility = ["//visibility:public"],  # Make the target visible to all packages
 )
 
 cc_library(
-    name = "hello_world_lib",
-    srcs = ["hello_world.cpp"],
-    hdrs = ["hello_world.h"],
+    name = "main_lib",
+    srcs = ["main.cpp"],
+    deps = [":hello_world_lib"],
     visibility = ["//visibility:public"],  # Make the target visible to all packages
 )
 

--- a/main/BUILD
+++ b/main/BUILD
@@ -1,6 +1,19 @@
 cc_library(
-    name = "hello_world",
+    name = "main_lib",
+    srcs = ["main.cpp", "hello_world.cpp"],
+    hdrs = ["hello_world.h"],
+    visibility = ["//visibility:public"],  # Make the target visible to all packages
+)
+
+cc_library(
+    name = "hello_world_lib",
     srcs = ["hello_world.cpp"],
     hdrs = ["hello_world.h"],
     visibility = ["//visibility:public"],  # Make the target visible to all packages
+)
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.cpp"],
+    deps = [":main_lib"],
 )

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,0 +1,8 @@
+// main/hello_world.cpp
+#include <iostream>
+#include "hello_world.h"
+
+
+int main(){
+    helloWorld();
+}

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,7 +2,7 @@ cc_test(
     name = "hello_world_test",
     srcs = ["hello_world_test.cpp"],
     deps = [
-        "//main:hello_world",
+        "//main:hello_world_lib",
         "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
This PR aims to include a binary build to the bazel template.
1- The project must to have a main function and main file to be able to build a binary. That is why I added the main.cpp file.
2- The project build must to have a build for the main project and for the cpp module to test. That is why there is two library builds. one for the module to test and one for the main project that uses the build of the module to test.
3- The test is oriented to the helloworld module and not to the complete project. 
 